### PR TITLE
Fix audio player test type errors and unused imports

### DIFF
--- a/src/__tests__/routing.integration.test.tsx
+++ b/src/__tests__/routing.integration.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
 import { Track } from '../types';

--- a/src/components/player/__tests__/AudioPlayer.integration.test.tsx
+++ b/src/components/player/__tests__/AudioPlayer.integration.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import { AudioPlayer } from '../AudioPlayer';
@@ -26,12 +26,13 @@ jest.mock('howler', () => ({
 }));
 
 const mockTrack = {
-  id: 1,
+  id: '1',
   title: '테스트 트랙',
   artist: '테스트 아티스트',
+  duration: 180,
+  file: '/audio/test.mp3',
   cover: '/covers/test.jpg',
-  audio: '/audio/test.mp3',
-  lyrics: '테스트 가사',
+  description: '테스트 트랙 설명',
 };
 
 describe('AudioPlayer Integration Tests', () => {


### PR DESCRIPTION
Fix TypeScript errors by updating `mockTrack` to conform to `Track` interface and removing unused `React` imports in test files.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0e6d64b-c3bf-4fed-9630-d667f98a0ac0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0e6d64b-c3bf-4fed-9630-d667f98a0ac0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>