### PR TITLE
Debug and fix web errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
     
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
-    <meta http-equiv="X-Frame-Options" content="DENY" />
     <meta http-equiv="X-XSS-Protection" content="1; mode=block" />
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
     
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#0ea5e9" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Moonwave" />

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,10 +20,10 @@ server {
     ssl_session_timeout 10m;
     
     # Security Headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     
@@ -49,10 +49,17 @@ server {
         image/svg+xml;
     
     # Cache static assets
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    location ~* \.(js|jsx|ts|tsx|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
         access_log off;
+    }
+    
+    # Handle TypeScript files with correct MIME type
+    location ~* \.(ts|tsx)$ {
+        add_header Content-Type "application/javascript";
+        expires 1y;
+        add_header Cache-Control "public, immutable";
     }
     
     # Cache audio files


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix web application errors by adjusting meta tags and Nginx configuration for proper MIME types and security headers.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `X-Frame-Options` error was due to setting it as a meta tag instead of an HTTP header. The `main.tsx` MIME type error was caused by Nginx serving TypeScript files with an incorrect `application/octet-stream` type. This PR corrects these by removing the meta tag, configuring Nginx to set the `X-Frame-Options` header, and ensuring `.ts`/`.tsx` files are served as `application/javascript`. It also updates a deprecated PWA meta tag and aligns other security headers.

---
<a href="https://cursor.com/background-agent?bcId=bc-047cb4b1-566c-4039-acf9-d00d85ba7489">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-047cb4b1-566c-4039-acf9-d00d85ba7489">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>