### PR TITLE
Fix eslint configuration error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,6 @@ export default tseslint.config(
       ],
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/prefer-const': 'error',
       'prefer-const': 'error',
       'no-var': 'error',
     },


### PR DESCRIPTION
Remove `@typescript-eslint/prefer-const` from ESLint configuration to fix linting errors caused by an invalid rule.

---
<a href="https://cursor.com/background-agent?bcId=bc-033c503f-b92c-4dce-8780-3d52ecd0b1ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-033c503f-b92c-4dce-8780-3d52ecd0b1ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>